### PR TITLE
Re-attach httpgd-based plot viewer after an R session is dropped and reattached

### DIFF
--- a/R/session/vsc.R
+++ b/R/session/vsc.R
@@ -829,6 +829,19 @@ attach <- function() {
     if (rstudioapi_enabled()) {
         rstudioapi_util_env$update_addin_registry(addin_registry)
     }
+    plot_url <- NULL
+    if (use_httpgd && requireNamespace("httpgd", quietly = TRUE)) {
+        tryCatch(
+            {
+                if (length(httpgd::hgd_details()) > 0) {
+                    plot_url <- httpgd::hgd_url()
+                }
+            },
+            error = function(e) {
+                plot_url <<- NULL
+            }
+        )
+    }
     request("attach",
         version = sprintf("%s.%s", R.version$major, R.version$minor),
         tempdir = tempdir,
@@ -837,12 +850,16 @@ attach <- function() {
             version = R.version.string,
             start_time = format(file.info(tempdir)$ctime)
         ),
-        plot_url = if (identical(names(dev.cur()), "httpgd")) httpgd::hgd_url(),
-        server = if (use_webserver) list(
-            host = host,
-            port = port,
-            token = token
-        ) else NULL
+        plot_url = plot_url,
+        server = if (use_webserver) {
+            list(
+                host = host,
+                port = port,
+                token = token
+            )
+        } else {
+            NULL
+        }
     )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "r",
   "displayName": "R",
   "description": "R Extension for Visual Studio Code",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "REditorSupport",
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "REditorSupport",

--- a/src/session.ts
+++ b/src/session.ts
@@ -1049,7 +1049,7 @@ async function updateRequest(sessionStatusBarItem: StatusBarItem) {
                         sessionStatusBarItem.text = `R ${rVer}: ${pid}`;
                         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
                         sessionStatusBarItem.tooltip = `${info?.version}\nProcess ID: ${pid}\nCommand: ${info?.command}\nStart time: ${info?.start_time}\nClick to attach to active terminal.`;
-                      //sessionStatusBarItem.show();  
+                        //sessionStatusBarItem.show();  
                         updateSessionWatcher();
 
                         if (request.server) {


### PR DESCRIPTION
This fix is to make the plot viewer re-attached to the R session again after an R session is dropped and re-attached. 

If an R session is dropped due to a restart of another extension, R's workspace could be restored after re-attaching the R session. However, the plot viewer won't be re-attached and shown in vscode after calling `plot()` even though plots are still being populated into external browser. 

