### PR TITLE
Live share fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "r",
-  "version": "3.0.1",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "r",
-      "version": "3.0.1",
+      "version": "3.0.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "ag-grid-community": "^31.3.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "r",
   "displayName": "R",
   "description": "R Extension for Visual Studio Code",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "author": "REditorSupport",
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "REditorSupport",
@@ -695,6 +695,13 @@
         "title": "Retry connection to Live Share service",
         "category": "R Live Share",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "r.liveShare.reshareHttpgd",
+        "title": "Re-share plot server (httpgd)",
+        "category": "R Live Share",
+        "enablement": "r.liveShare:isGuest == false",
+        "icon": "$(cloud-upload)"
       },
       {
         "title": "Toggle Style",

--- a/src/liveShare/shareTree.ts
+++ b/src/liveShare/shareTree.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 import { requestFile } from '../session';
 
 import { config } from '../util';
-import { isLiveShare, rHostService } from '.';
+import { globalHttpgdManager } from '../extension';
+import { isLiveShare, rHostService, liveShareRequest, Callback } from '.';
 
 export let forwardCommands: boolean;
 export let shareWorkspace: boolean;
@@ -103,8 +104,17 @@ class ShareNode extends ToggleNode {
         this.description = shareWorkspace === true ? 'Enabled' : 'Disabled';
         if (shareWorkspace) {
             void rHostService?.notifyRequest(requestFile, true);
+            if (isLiveShare()) {
+                void liveShareRequest(Callback.NotifyMessage, 'Host has enabled R workspace sharing.', 'information');
+            }
         } else {
             void rHostService?.orderGuestDetach();
+            if (isLiveShare()) {
+                void liveShareRequest(Callback.NotifyMessage, 'Host has disabled R workspace sharing.', 'warning');
+            }
+            if (autoShareBrowser) {
+                globalHttpgdManager?.disposeSharedServers();
+            }
         }
         treeProvider.refresh();
     }

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -370,11 +370,7 @@ export function loadWorkspace(): void {
 }
 
 export function viewItem(node: string): void {
-    if (isLiveShare()) {
-        void runTextInTerm(`View(${node}, uuid = ${UUID})`);
-    } else {
-        void runTextInTerm(`View(${node})`);
-    }
+    void runTextInTerm(`View(${node})`);
 }
 
 export function removeItem(node: string): void {


### PR DESCRIPTION
File/content requests fixes to make live share work again
- Live Share callbacks now correctly unpack args arrays (host receives [context, path, encoding]).

Data viewer in guest given earlier data viewer model change
- Added Live Share path so guest data viewer can fetch rows through host’s R server.

Made guest-side more restrictive
- Guest only attaches to the host R session after explicit user action (Guest R: (not attached) → click to attach). No auto‑attach.
- Attach requests are ignored unless the host has a live R session (no server → no attach) and the guest actually requested attach.
- Guest UI/data access is gated by attachment:
    - Workspace view, data viewer, and plot viewer only update once attached.
    - Requests are dropped while not attached.
    - httpgd server could be re-attached via new command: R Live Share: Re-share plot server (httpgd)
- Guest is fully detached on host session end:
    - Workspace data cleared.
    - Data viewers and plot viewers closed.
    - Shared servers cleaned up.
 
Some other change
- dispose opened viewers when an extension restarts, but R session not ended but re-attachable. Otherwise, a new viewer would pop up if the old viewer is not closed during extension restart. 